### PR TITLE
Add JSON support, HTTP code support and credentials changing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,29 @@ return DirectAdmin::postAccountAdmin([
 
 Magic Methods are named after the method (get/post) followed by the command without `CMD_API_` in CamelCase. So, if you want to make a GET request with the CMD_API_SHOW_ALL_USERS command, the magic method would be `getShowAllUsers()`.
 
+### JSON Support
+
+It's possible to use JSON support, this allows using the HTTP code for feedback.
+No more annoying login screen errors on invalid login parameters.
+
+```php
+$data = DirectAdmin::get()->requestJSON('SHOW_USERS');
+$respone = DirectAdmin::get_status_code();
+```
+
+Also added magic methods support:
+```php
+$data = DirectAdmin::getjsonShowUsers();
+```
+
+### Change user during runtime
+
+It's also possible to change the user during runtime as shown below:
+
+```php
+DirectAdmin::set_login('username', 'password')
+```
+
 ## Credits
 - [Phi1 'l0rdphi1' Stier](mailto:l0rdphi1@liquenox.net)
 - [Joshua de Gier / Pendo](https://github.com/PendoNL)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ No more annoying login screen errors on invalid login parameters.
 
 ```php
 $data = DirectAdmin::get()->requestJSON('SHOW_USERS');
-$respone = DirectAdmin::get_status_code();
+$response = DirectAdmin::get_status_code();
 ```
 
 Also added magic methods support:

--- a/src/LaravelDirectAdmin.php
+++ b/src/LaravelDirectAdmin.php
@@ -45,6 +45,30 @@ class LaravelDirectAdmin
         $this->connection->query('/CMD_API_'.$command, $options);
         return $this->connection->fetch_parsed_body();
     }
+    
+    /**
+     * Return the last HTTP status code.
+	 * 200 = OK;
+	 * 403 = FORBIDDEN;
+	 * etc.
+     *
+     * @return int HTTP status code
+     */
+    public function get_status_code()
+    {
+        return $this->connection->get_status_code();
+    }
+    
+    /**
+	 * Specify a username and password.
+	 *
+	 * @param string|null username. default is null
+	 * @param string|null password. default is null
+	 */
+    public function set_login($username, $password)
+    {
+        $this->connection->set_login($username, $password);
+    }
 
     /**
      * Magic Method

--- a/src/LaravelDirectAdmin.php
+++ b/src/LaravelDirectAdmin.php
@@ -47,9 +47,10 @@ class LaravelDirectAdmin
     }
 
     /**
-     * Do an API request.
+     * Do an API request with JSON as an answer.
+     * HTTP response codes are working with JSON requests.
      *
-     * @return array result parsed
+     * @return array json parsed
      */
     public function requestjson($command, $options = [])
     {


### PR DESCRIPTION
Allows changing credentials during runtime with the command (Fixes #12):
```php
DirectAdmin::set_login('username', 'password');
```
Allows JSON support and HTTP code support to get proper error feedback.
Changed documentation with new additions. 