### PR TITLE
Updated return type

### DIFF
--- a/src/LaravelDirectAdmin.php
+++ b/src/LaravelDirectAdmin.php
@@ -50,7 +50,7 @@ class LaravelDirectAdmin
      * Do an API request with JSON as an answer.
      * HTTP response codes are working with JSON requests.
      *
-     * @return array json parsed
+     * @return object JSON parsed
      */
     public function requestJson($command, $options = [])
     {


### PR DESCRIPTION
Return type of `requestJson` is not correct. It does not convert it to an associative array. PHPStorm was whining about it. ;-)